### PR TITLE
Fix "Auto E when a minion can die and enemies have 1+ stacks"

### DIFF
--- a/Kalista/Modes/PermaActive.cs
+++ b/Kalista/Modes/PermaActive.cs
@@ -56,7 +56,14 @@ namespace Hellsing.Kalista.Modes
                 if (Settings.UseHarassPlus)
                 {
                     if (HeroManager.Enemies.Any(o => E.IsInRange(o) && o.HasRendBuff()) &&
-                        ObjectManager.Get<Obj_AI_Base>().Any(o => E.IsInRange(o) && o.IsRendKillable()) &&
+                        ObjectManager.Get<Obj_AI_Base>().Any(o => {
+                            if (!o.IsAlly && o.IsValidTarget(E.Range) && o.HasRendBuff())
+                            {
+                                return o.IsRendKillable();
+                            }
+                            return false;
+                        }
+                        ) &&
                         E.Cast())
                     {
                         return;


### PR DESCRIPTION
Now correcly check if the minion is an enemy minion and valid target.
