### PR TITLE
fixed a bug causing modes not to be executed

### DIFF
--- a/Kalista/Modes/Combo.cs
+++ b/Kalista/Modes/Combo.cs
@@ -9,12 +9,12 @@ namespace Hellsing.Kalista.Modes
     {
         public override bool ShouldBeExecuted()
         {
-            if (new GameObject().Type == GameObjectType.obj_AI_Minion)
-            {
-                if (!string.IsNullOrWhiteSpace(new GameObject().Name))
-                {
-                }
-            }
+            //if (new GameObject().Type == GameObjectType.obj_AI_Minion)
+            //{
+                //if (!string.IsNullOrWhiteSpace(new GameObject().Name))
+                //{
+                //}
+            //}
             return Orbwalker.ActiveModesFlags.HasFlag(Orbwalker.ActiveModes.Combo);
         }
 


### PR DESCRIPTION
Hi, 
I think there is a bug in your Kalista Addon, causing every modelogic except PermaActive to not execute. Looks like you put in some lines by accident or something. Thank you for EB btw! :D
